### PR TITLE
Handle exchange authentication errors

### DIFF
--- a/Exec-HuduM365ProcessTenant/run.ps1
+++ b/Exec-HuduM365ProcessTenant/run.ps1
@@ -393,7 +393,6 @@ try {
                 $CASFull = $null
             }
         } else {
-            $CompanyResult.Errors.add("Company: Unable to fetch CAS Mailbox Details $_")
             $CASFull = $null
         }
        

--- a/Exec-HuduM365ProcessTenant/run.ps1
+++ b/Exec-HuduM365ProcessTenant/run.ps1
@@ -43,9 +43,16 @@ try {
 
         $company_name = $hududomain[0].company_name
         $company_id = $hududomain[0].company_id
-    
+        $ExchangeAuthenticated = $true
+
         try {
             $ExchangeAuthHeaders = Get-GraphToken -AppID 'a0c73c16-a7e3-4564-9a95-2bdf47383716' -RefreshToken $env:ExchangeRefreshToken -Scope 'https://outlook.office365.com/.default' -Tenantid $TenantFilter
+        } catch {
+            $CompanyResult.Errors.Add("Failed to get Exchange Auth Headers")
+            $ExchangeAuthenticated = $false
+        }
+
+        try{
             $Authheaders = Get-GraphToken -tenantid $TenantFilter
         } catch {
             Throw "Failed to authenticate to tenant"
@@ -378,13 +385,18 @@ try {
             $OneDriveDetails = $null
         }
 
-        try {
-            $CASFull = New-GraphGetRequest -Headers $ExchangeAuthHeaders -uri "https://outlook.office365.com/adminapi/beta/$($tenantfilter)/CasMailbox" -Tenantid $tenantfilter -scope ExchangeOnline -noPagination $true
-        } catch {
+        if ($ExchangeAuthenticated) {
+            try {
+                $CASFull = New-GraphGetRequest -Headers $ExchangeAuthHeaders -uri "https://outlook.office365.com/adminapi/beta/$($tenantfilter)/CasMailbox" -Tenantid $tenantfilter -scope ExchangeOnline -noPagination $true
+            } catch {
+                $CompanyResult.Errors.add("Company: Unable to fetch CAS Mailbox Details $_")
+                $CASFull = $null
+            }
+        } else {
             $CompanyResult.Errors.add("Company: Unable to fetch CAS Mailbox Details $_")
             $CASFull = $null
         }
-            
+       
         try {
             $MailboxDetailedFull = New-ExoRequest -TenantID $TenantFilter -cmdlet 'Get-Mailbox'
         } catch {
@@ -439,12 +451,17 @@ try {
                     $CASRequest = $CASFull | where-object { $_.ExternalDirectoryObjectId -eq $User.iD }
                     $MailboxDetailedRequest = $MailboxDetailedFull | where-object { $_.ExternalDirectoryObjectId -eq $User.iD }
                     $StatsRequest = $MailboxStatsFull | where-object { $_.'User Principal Name' -eq $User.UserPrincipalName }
-
-                    try {
-                        $PermsRequest = New-GraphGetRequest -Headers $ExchangeAuthHeaders -uri "https://outlook.office365.com/adminapi/beta/$($tenantfilter)/Mailbox('$($User.ID)')/MailboxPermission" -Tenantid $tenantfilter -scope ExchangeOnline -noPagination $true
-                    } catch {
+                    
+                    if ($ExchangeAuthenticated) {
+                        try {
+                            $PermsRequest = New-GraphGetRequest -Headers $ExchangeAuthHeaders -uri "https://outlook.office365.com/adminapi/beta/$($tenantfilter)/Mailbox('$($User.ID)')/MailboxPermission" -Tenantid $tenantfilter -scope ExchangeOnline -noPagination $true
+                        } catch {
+                            $PermsRequest = $null
+                        }
+                    } else {
                         $PermsRequest = $null
                     }
+
 
                     $ParsedPerms = foreach ($Perm in $PermsRequest) {
                         if ($Perm.User -ne 'NT AUTHORITY\SELF') {


### PR DESCRIPTION
Right now if the script is unable to authenticate to exchange the script will error out completely even though exchange is not required for most requests / stats.

The pull requests makes sure that if there are any issues it will still run everything else.

main error I was running in that is fixed now:
```
Invoke-RestMethod : {"error":"invalid_resource","error_description":"AADSTS500014: The service principal for resource 'https://outlook.office365.com' is disabled. This indicate that a
subscription within the tenant has lapsed, or that the administrator for this tenant has disabled the application, preventing tokens from being issued for it.\r\nTrace ID:
8fd8421c-4adc-405f-92f9-f2bd61326000\r\nCorrelation ID: 46d130f0-2301-45c2-9b6b-e848bc7502b9\r\nTimestamp: 2022-02-03 11:11:23Z","error_codes":[500014],"timestamp":"2022-02-03
11:11:23Z","trace_id":"8fd8421c-4adc-405f-92f9-f2bd61326000","correlation_id":"46d130f0-2301-45c2-9b6b-e848bc7502b9"}
```


The code it is quite simple it splits up 
```powershell
$ExchangeAuthHeaders = Get-GraphToken -AppID 'a0c73c16-a7e3-4564-9a95-2bdf47383716' -RefreshToken $env:ExchangeRefreshToken -Scope 'https://outlook.office365.com/.default' -Tenantid $TenantFilter
```
and
```powershell
$Authheaders = Get-GraphToken -tenantid $TenantFilter
```
in two seperate try catch statements


if the exchange auth fails it will set $ExchangeAuthenticated to $false. $ExchangeAuthenticated  is then wrapped around all statements that need exchange with a if statement so they get skipped if it is set to $false.

_As side note, Really like the project!_